### PR TITLE
Update decayMonteCarlo_full.py

### DIFF
--- a/decayMonteCarlo_full.py
+++ b/decayMonteCarlo_full.py
@@ -107,7 +107,7 @@ def decayMonteCarlo(*, param, monitoredIdx, max_steps, averagingSteps, tol,
             param.rate_constants = oldRateConstants
 
         allEnergies[i] = energy
-        tau_print = tau * 10e5
+        tau_print = tau * 1e6
         # print("step:", i, "of", nSteps, " temperature:", temperatures[i], " energy:", energy)
         log.write(f"step: {i} of {nSteps}, temperature: {temperatures[i]}, energy: {energy}\n")
         log.flush()


### PR DESCRIPTION
tau_print = tau * 10*1e5 before, changed it to tau * 1 e6, since they are equivalent and this is easier way to express the conversion to microseconds